### PR TITLE
fix bugs when function with no args in css

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -346,7 +346,7 @@ KatanaArray* katana_new_array(KatanaParser* parser) {
 
 void katana_destroy_array_using_deallocator(KatanaParser* parser,
                           KatanaArrayDeallocator callback, KatanaArray* array) {
-    assert(NULL != array);
+    //assert(NULL != array);
     if ( NULL == array )
         return;
     for (size_t i = 0; i < array->length; ++i) {


### PR DESCRIPTION
when a css code like this: `filter:mask()`,  the function mask has no args, then the 
'array'  arg will be null in function 'katana_destroy_array_using_deallocator' 
