### PR TITLE
Fix uninitialized value use when parsing pseudos

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -997,6 +997,7 @@ KatanaSelector* katana_new_selector(KatanaParser* parser)
     selector->data = katana_new_rare_data(parser);
     selector->tag = NULL;
     selector->match = 0;
+    selector->pseudo = KatanaPseudoNotParsed;
     selector->relation = 0;
     selector->specificity = 0;
     selector->tag = NULL;

--- a/src/selector.c
+++ b/src/selector.c
@@ -65,7 +65,7 @@ KatanaPseudoType katana_parse_pseudo_type(const char* name, bool hasArguments)
 
 void katana_selector_extract_pseudo_type(KatanaSelector* selector)
 {
-    if (selector->pseudo == KatanaPseudoUnknown)
+    if (selector->pseudo == KatanaPseudoNotParsed)
         selector->pseudo = KatanaPseudoUnknown;
     
     if (selector->match != KatanaSelectorMatchPseudoClass && selector->match != KatanaSelectorMatchPseudoElement && selector->match != KatanaSelectorMatchPagePseudoClass)


### PR DESCRIPTION
Valgrind complains about this as "conditional jump or move depends on uninitialized value(s)". Although it was harmless from what I can tell, better to avoid such things.

The `KatanaPseudoNotParsed` wasn't even used so far. It could be removed, but I think it might be useful for debugging state changes while parsing.
Also, the if-statement could be removed entirely if we just wanted to fix the uninitialized value use, that wouldn't change anything. I'd suggest to leave the KatanaSelector.pseudo initialization though, I got fooled into thinking this would be used a bitflag-field for a moment (since random bits were set).