### PR TITLE
fix wrong logic for katana_print_media_query()

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1459,7 +1459,7 @@ void katana_print_media_query(KatanaParser* parser, KatanaMediaQuery* query)
             return;
         }
         
-        if ( (NULL != query->type && !strcasecmp(query->type, "all")) || query->restrictor != KatanaMediaQueryRestrictorNone) {
+        if ( (NULL != query->type && strcasecmp(query->type, "all")) || query->restrictor != KatanaMediaQueryRestrictorNone) {
             if ( NULL != query->type ) {
                 katana_print("%s", query->type);
             }


### PR DESCRIPTION
Old version is wrong. For example for this simple css
```
@media screen and (min-width: 768px) {
  .selector{
    property: value;
  }
}
```
it return such dump
```
@media (min-width: 768px) {
.selector {
  property: value;
}
}
```
instead of
```
@media screen and (min-width: 768px) {
.selector {
  property: value;
}
}
```